### PR TITLE
resolve base id length error

### DIFF
--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 48;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -69,30 +69,30 @@
 		46CDAC6C1187C5467E576980E1062C8B /* SessionManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SessionManager.swift; path = Source/SessionManager.swift; sourceTree = "<group>"; };
 		4AF006B0AD5765D1BFA8253C2DCBB126 /* AFError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AFError.swift; path = Source/AFError.swift; sourceTree = "<group>"; };
 		4E5EB79B1CEDE183A4C46A70F4AE64EA /* Pods-mTag-SDK-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-mTag-SDK-umbrella.h"; sourceTree = "<group>"; };
-		5593545482086F549F9C72B735752032 /* Pods_mTag_SDKTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_mTag_SDKTests.framework; path = "Pods-mTag-SDKTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5593545482086F549F9C72B735752032 /* Pods_mTag_SDKTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_mTag_SDKTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		60AF4956862E930893DA84A9F6BC56E7 /* Pods-mTag-SDK-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-mTag-SDK-resources.sh"; sourceTree = "<group>"; };
 		6604A7D69453B4569E4E4827FB9155A9 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		6639346628280A0D0FAD35196BF56108 /* ParameterEncoding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ParameterEncoding.swift; path = Source/ParameterEncoding.swift; sourceTree = "<group>"; };
 		66A46F517F0AF7E85A16D723F6406896 /* Notifications.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Notifications.swift; path = Source/Notifications.swift; sourceTree = "<group>"; };
 		6722453FC0FEA00B95D7FEDF7687D0F2 /* Pods-mTag-SDK-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-mTag-SDK-dummy.m"; sourceTree = "<group>"; };
 		6A8724AEA2D766696C626792EC283328 /* Pods-mTag-SDKTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-mTag-SDKTests-umbrella.h"; sourceTree = "<group>"; };
-		707DEAE1614D43E1643F0B4BC24C5F5F /* Alamofire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Alamofire.framework; path = Alamofire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		7D141D1953E5C6E67E362CE73090E48A /* Alamofire.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = Alamofire.modulemap; sourceTree = "<group>"; };
+		707DEAE1614D43E1643F0B4BC24C5F5F /* Alamofire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Alamofire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7D141D1953E5C6E67E362CE73090E48A /* Alamofire.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Alamofire.modulemap; sourceTree = "<group>"; };
 		869621FA662094F153988B1B252C6555 /* Pods-mTag-SDK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-mTag-SDK.debug.xcconfig"; sourceTree = "<group>"; };
 		87882A1F5A92C8138D54545E51D51E6F /* Timeline.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Timeline.swift; path = Source/Timeline.swift; sourceTree = "<group>"; };
 		8CF01C79A7CAD31C7CA2F33DB26BAFEB /* Pods-mTag-SDKTests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-mTag-SDKTests-resources.sh"; sourceTree = "<group>"; };
 		9085C18992E43B4EF5E99CD3C013E6C7 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		93CAB2E491B8E48CA539844043A7BED6 /* Pods-mTag-SDK-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-mTag-SDK-acknowledgements.markdown"; sourceTree = "<group>"; };
 		A01C037B4034EDA3D7955BC5E4E9D9D6 /* TaskDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TaskDelegate.swift; path = Source/TaskDelegate.swift; sourceTree = "<group>"; };
-		A555949B88BFD7577E3DCCD87FC56DFB /* Pods_mTag_SDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_mTag_SDK.framework; path = "Pods-mTag-SDK.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A555949B88BFD7577E3DCCD87FC56DFB /* Pods_mTag_SDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_mTag_SDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC9F3F9064CAE62A1471EE0903DE2DE1 /* Pods-mTag-SDKTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-mTag-SDKTests.release.xcconfig"; sourceTree = "<group>"; };
 		B029DBC43E49A740F12B5E4D2E6DD452 /* Validation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Validation.swift; path = Source/Validation.swift; sourceTree = "<group>"; };
 		B44A27EFBB0DA84D738057B77F3413B1 /* Alamofire-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Alamofire-umbrella.h"; sourceTree = "<group>"; };
-		B502185F5A2A05B1B4F2073CB8B3ECBB /* Pods-mTag-SDKTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-mTag-SDKTests.modulemap"; sourceTree = "<group>"; };
+		B502185F5A2A05B1B4F2073CB8B3ECBB /* Pods-mTag-SDKTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-mTag-SDKTests.modulemap"; sourceTree = "<group>"; };
 		BB4666DCF1CA0EFB22F693E94E3DAD82 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BCCA9CA7D9C1A2047BB93336C5708DFD /* Alamofire-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Alamofire-prefix.pch"; sourceTree = "<group>"; };
-		BDCD816E533298137A40A975B7796646 /* Pods-mTag-SDK.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-mTag-SDK.modulemap"; sourceTree = "<group>"; };
+		BDCD816E533298137A40A975B7796646 /* Pods-mTag-SDK.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-mTag-SDK.modulemap"; sourceTree = "<group>"; };
 		CAE81204138375DADE72489F39FB6E74 /* Pods-mTag-SDKTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-mTag-SDKTests-dummy.m"; sourceTree = "<group>"; };
 		DA0C91D6DCB300D3C777C280370FD750 /* Pods-mTag-SDKTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-mTag-SDKTests-acknowledgements.plist"; sourceTree = "<group>"; };
 		DFCB8C44DE758E906C0BCDA455937B85 /* Alamofire.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Alamofire.swift; path = Source/Alamofire.swift; sourceTree = "<group>"; };
@@ -152,7 +152,6 @@
 				B029DBC43E49A740F12B5E4D2E6DD452 /* Validation.swift */,
 				55F14F994FE7AB51F028BFE66CEF3106 /* Support Files */,
 			);
-			name = Alamofire;
 			path = Alamofire;
 			sourceTree = "<group>";
 		};
@@ -349,7 +348,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0830;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0920;
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -625,7 +624,9 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
@@ -633,14 +634,20 @@
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGNING_REQUIRED = NO;
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"POD_CONFIGURATION_RELEASE=1",
 					"$(inherited)",
@@ -708,7 +715,9 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
@@ -716,15 +725,21 @@
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGNING_REQUIRED = NO;
 				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"POD_CONFIGURATION_DEBUG=1",

--- a/mTag-SDK/API.swift
+++ b/mTag-SDK/API.swift
@@ -21,7 +21,7 @@ open class API: NSObject {
   // length of a base 10 format mTag ID
   static let MTAG_ID_B10_LENGTH: Int = 8
   // length of a base 36 format mTag ID
-  static let MTAG_ID_B36_LENGTH: Int = 5
+  static let MTAG_ID_B36_LENGTH: Int = 6
   // length of tech prefix affixed to mTag ID
   static let TECH_PREFIX: Int = 1
 
@@ -88,7 +88,7 @@ open class API: NSObject {
   class func parseIdFrom(url: String) -> String? {
     var urlTail = url.components(separatedBy: "/").last!
 
-    if urlTail.count == MTAG_ID_B10_LENGTH + TECH_PREFIX || urlTail.count == MTAG_ID_B36_LENGTH + TECH_PREFIX {
+    if urlTail.count <= MTAG_ID_B10_LENGTH + TECH_PREFIX || urlTail.count <= MTAG_ID_B36_LENGTH + TECH_PREFIX {
       urlTail.remove(at: urlTail.startIndex) // drop tech type
       return convertIdToBase10(urlTail)
     }
@@ -119,7 +119,7 @@ open class API: NSObject {
         return nil
       }
     }
-    else if id.count == MTAG_ID_B36_LENGTH {
+    else if id.count <= MTAG_ID_B36_LENGTH {
       return String(strtoul(id, nil, 36))
     }
     else {
@@ -235,8 +235,15 @@ open class API: NSObject {
     formattedResponse["deviceCountry"] = device?["country"] as? String ?? nil
 
     formattedResponse["tagVerified"] = jsonAsDict["tag_verified"] as? String ?? nil
-    formattedResponse["campaigns"] = jsonAsDict["campaigns"] as? [String: Any] ?? nil
     formattedResponse["location"] = jsonAsDict["location"] as? [String: Any] ?? nil
+
+    // make sure we get either a single campaign or multiple campaigns (if there are multiple)
+    if let campaigns = jsonAsDict["campaigns"] as? [String: Any] {
+      formattedResponse["campaigns"] = campaigns
+    }
+    else {
+      formattedResponse["campaigns"] = jsonAsDict["campaigns"] as? [Any] ?? nil
+    }
 
     // TODO: This could be deprecated by using Struct/encoding, but this seems safer
     if var location = formattedResponse["location"] as? [String: Any] {

--- a/mTag-SDKTests/mTag_SDKTests.swift
+++ b/mTag-SDKTests/mTag_SDKTests.swift
@@ -16,7 +16,7 @@ class mTag_SDKTests: XCTestCase, BlueBiteInteractionDelegate {
   // MARK: BlueBiteInteractionDelegate
   func interactionDataWasReceived(withResults result: [String : Any]) {
     print("response was received: \(result)")
-    if result["location"] != nil && result["campaigns"] != nil && result["deviceCountry"] == "US" {
+    if result["location"] != nil && result["campaigns"] != nil && result["deviceCountry"] as? String == "US" {
       basicTagSuccessExpectation?.fulfill()
     }
   }
@@ -49,7 +49,7 @@ class mTag_SDKTests: XCTestCase, BlueBiteInteractionDelegate {
     API.interactionWasReceived(withUrl: url)
     self.waitForExpectations(timeout: 10.0, handler: nil)
   }
-  
+
   /*
    Calls to API.convertIdToBase10(_ id:) should:
    - Receive a potential mTag ID and successfully parse it and convert it to Base 10.
@@ -68,9 +68,6 @@ class mTag_SDKTests: XCTestCase, BlueBiteInteractionDelegate {
     res = API.convertIdToBase10("1234567#")
     XCTAssertNil(res)
     
-    //test invalid id too short
-    res = API.convertIdToBase10("123")
-    XCTAssertNil(res)
     //test invalid id too long
     res = API.convertIdToBase10("1234567890")
     XCTAssertNil(res)


### PR DESCRIPTION
Failed to account for mTag IDs' base 36 length extending to 6 characters as their b10 values continue to grow.  Simply needed to increase the length constant and shift to less-than-or-equal-to instead of equal-to comparisons.