### PR TITLE
Hid auth fixes

### DIFF
--- a/mTag-SDK/API.swift
+++ b/mTag-SDK/API.swift
@@ -159,7 +159,7 @@ open class API: NSObject {
     var urlArgs = urlParts.last!.components(separatedBy: "?").last!.components(separatedBy: "&")
 
     var params: [String: String] = [:]
-    let expectedArgs = ["tagID": "hid", "tagId": "hid", "tac": "vid"]
+    let expectedArgs = ["tagID": "hid", "tac": "vid"]
     for urlArg in urlArgs {
       let splitArg = urlArg.components(separatedBy: "=")
       let argName = String(splitArg[0])

--- a/mTag-SDK/API.swift
+++ b/mTag-SDK/API.swift
@@ -139,7 +139,7 @@ open class API: NSObject {
     let urlArgs = urlParts.last!.components(separatedBy: "?").last!.components(separatedBy: "&")
 
     var params: [String: String] = [:]
-    let expectedArgs = ["id": "tag_uid", "num": "tag_version", "sig": "tag_signature"]
+    let expectedArgs = ["id": "uid", "num": "tag_version", "sig": "vid"]
     for urlArg in urlArgs {
       let splitArg = urlArg.components(separatedBy: "=")
       let argName = String(splitArg[0])
@@ -160,7 +160,7 @@ open class API: NSObject {
     var urlArgs = urlParts.last!.components(separatedBy: "?").last!.components(separatedBy: "&")
 
     var params: [String: String] = [:]
-    let expectedArgs = ["tagID": "tagID", "tagId": "tagID", "tac": "tac"]
+    let expectedArgs = ["tagID": "hid", "tagId": "hid", "tac": "vid"]
     for urlArg in urlArgs {
       let splitArg = urlArg.components(separatedBy: "=")
       let argName = String(splitArg[0])

--- a/mTag-SDK/API.swift
+++ b/mTag-SDK/API.swift
@@ -160,7 +160,7 @@ open class API: NSObject {
     var urlArgs = urlParts.last!.components(separatedBy: "?").last!.components(separatedBy: "&")
 
     var params: [String: String] = [:]
-    let expectedArgs = ["tagId": "tagID", "tac": "tac"]
+    let expectedArgs = ["tagID": "tagID", "tagId": "tagID", "tac": "tac"]
     for urlArg in urlArgs {
       let splitArg = urlArg.components(separatedBy: "=")
       let argName = String(splitArg[0])
@@ -234,7 +234,17 @@ open class API: NSObject {
     let device = jsonAsDict["device"] as? [String: Any] ?? nil
     formattedResponse["deviceCountry"] = device?["country"] as? String ?? nil
 
-    formattedResponse["tagVerified"] = jsonAsDict["tag_verified"] as? String ?? nil
+    // get tagVerified.  Should return as Int but check for String just for robustness
+    if let verified = jsonAsDict["tag_verified"] as? Int {
+      formattedResponse["tagVerified"] = verified == 1 ? true : false
+    }
+    else if let verified = jsonAsDict["tag_verified"] as? String {
+      formattedResponse["tagVerified"] = verified.lowercased() == "true" ? true : false
+    }
+    else {
+      // probably wasn't included so just leave it out
+    }
+
     formattedResponse["location"] = jsonAsDict["location"] as? [String: Any] ?? nil
 
     // make sure we get either a single campaign or multiple campaigns (if there are multiple)

--- a/mTag-SDK/API.swift
+++ b/mTag-SDK/API.swift
@@ -128,7 +128,6 @@ open class API: NSObject {
     }
   }
 
-  // TODO VERIFY PARAM KEYS USING ANDROID NFC VERIFICATION CODE
   /**
    Parses an Auth URL into a dictionary.
    ex: https:// mtag.io/n10130797?id=<UID>&num=<Number>&sig=<Signature>

--- a/mTag-SDKTests/mTag_SDKTests.swift
+++ b/mTag-SDKTests/mTag_SDKTests.swift
@@ -115,12 +115,12 @@ class mTag_SDKTests: XCTestCase, BlueBiteInteractionDelegate {
     // test good auth url
     var targetUrl: String = "https://mtag.io/njaix4?id=1234567&num=890123&sig=456789"
     var res = API.handleAuthUrl(withUrlParts: targetUrl.components(separatedBy: "/"))
-    XCTAssertEqual(res, ["tag_signature": "456789", "tag_version": "890123", "tag_uid": "1234567"])
+    XCTAssertEqual(res, ["vid": "456789", "tag_version": "890123", "uid": "1234567"])
     
     // test good hid url
     targetUrl = "https://mtag.io/njaix4?tagID=654321&tac=123456"
     res = API.handleHidUrl(withUrlParts: targetUrl.components(separatedBy: "/"))
-    XCTAssertEqual(res, ["tac": "123456", "tagID": "654321"])
+    XCTAssertEqual(res, ["vid": "123456", "hid": "654321"])
     
     // test good counter url
     targetUrl = "https://mtag.io/njaix4/12345678x1234561234"
@@ -130,12 +130,12 @@ class mTag_SDKTests: XCTestCase, BlueBiteInteractionDelegate {
     // test bad auth url
     targetUrl = "https://mtag.io/njaix4?badkey=failure&id=1234567&num=890123&sig=456789"
     res = API.handleAuthUrl(withUrlParts: targetUrl.components(separatedBy: "/"))
-    XCTAssertEqual(res, ["tag_signature": "456789", "tag_version": "890123", "tag_uid": "1234567"])
+    XCTAssertEqual(res, ["vid": "456789", "tag_version": "890123", "uid": "1234567"])
     
     // test bad hid url
     targetUrl = "https://mtag.io/njaix4?tagId=654321&badfield=yes&tac=123456"
     res = API.handleHidUrl(withUrlParts: targetUrl.components(separatedBy: "/"))
-    XCTAssertEqual(res, ["tac": "123456", "tagID": "654321"])
+    XCTAssertEqual(res, ["vid": "123456", "hid": "654321"])
     
     // test bad counter url
     targetUrl = "https://mtag.io/njaix4/12345678x1234561234?thisShouldnt=beHere"

--- a/mTag-SDKTests/mTag_SDKTests.swift
+++ b/mTag-SDKTests/mTag_SDKTests.swift
@@ -133,7 +133,7 @@ class mTag_SDKTests: XCTestCase, BlueBiteInteractionDelegate {
     XCTAssertEqual(res, ["vid": "456789", "tag_version": "890123", "uid": "1234567"])
     
     // test bad hid url
-    targetUrl = "https://mtag.io/njaix4?tagId=654321&badfield=yes&tac=123456"
+    targetUrl = "https://mtag.io/njaix4?tagID=654321&badfield=yes&tac=123456"
     res = API.handleHidUrl(withUrlParts: targetUrl.components(separatedBy: "/"))
     XCTAssertEqual(res, ["vid": "123456", "hid": "654321"])
     

--- a/mTag-SDKTests/mTag_SDKTests.swift
+++ b/mTag-SDKTests/mTag_SDKTests.swift
@@ -118,7 +118,7 @@ class mTag_SDKTests: XCTestCase, BlueBiteInteractionDelegate {
     XCTAssertEqual(res, ["tag_signature": "456789", "tag_version": "890123", "tag_uid": "1234567"])
     
     // test good hid url
-    targetUrl = "https://mtag.io/njaix4?tagId=654321&tac=123456"
+    targetUrl = "https://mtag.io/njaix4?tagID=654321&tac=123456"
     res = API.handleHidUrl(withUrlParts: targetUrl.components(separatedBy: "/"))
     XCTAssertEqual(res, ["tac": "123456", "tagID": "654321"])
     


### PR DESCRIPTION
Added support for receiving `tag_verified` as either an Int or a String, which should resolve any missing `tagVerified` issues.

Also changed params to the expected API values.