### PR TITLE
SDK-37: Add no header cookie flag

### DIFF
--- a/mTag-SDK.podspec
+++ b/mTag-SDK.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "mTag-SDK"
-  s.version      = "1.0.0"
+  s.version      = "1.1.0"
   s.summary      = "Facilitates registering NFC Interactions with the Blue Bite API."
 
   # This description is used to generate tags and improve search results.

--- a/mTag-SDK/API.swift
+++ b/mTag-SDK/API.swift
@@ -47,6 +47,10 @@ open class API: NSObject {
   // user-accessible flag to enable overwriting Alamofire's default User-Agent
   open static var overrideUserAgent: Bool = false
 
+  // user-accessible flag to enable overwriting the request's cookie.
+  // mostly included for compatibility with Decode
+  open static var overrideHeaderCookie: Bool = false
+
   /**
    Simple logger to prevent extra noise during production.
    */
@@ -215,10 +219,12 @@ open class API: NSObject {
     _log("Params: \(mutableParams)", level: "DEBUG")
 
     // override the user agent if the user chooses
-    var additionalHeaders : [String: String]?
+    var additionalHeaders : [String: String] = [:]
     if self.overrideUserAgent {
-      additionalHeaders = [:]
-      additionalHeaders!["User-Agent"] = "mTag-SDK request/Alamofire4.x"
+      additionalHeaders["User-Agent"] = "mTag-SDK request/Alamofire4.x"
+    }
+    if self.overrideHeaderCookie {
+      additionalHeaders["Cookie"] = ""
     }
 
     let targetUrl = "https://api.mtag.io/v2/interactions"

--- a/mTag-SDK/Info.plist
+++ b/mTag-SDK/Info.plist
@@ -15,12 +15,12 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
-	<key>NSPrincipalClass</key>
-	<string></string>
 	<key>NSAllowsArbitraryLoads</key>
 	<true/>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>


### PR DESCRIPTION
Added a boolean flag that explicitly clears the request header's `Cookie` field.

This is really only necessary for Decode, as there is some funky backend code that was affecting certain instances of the app.  Does not otherwise alter or impede normal workflow.