### PR TITLE
DEC-162: Check slug length on url submission

### DIFF
--- a/mTag-SDK.podspec
+++ b/mTag-SDK.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "mTag-SDK"
-  s.version      = "1.1.0"
+  s.version      = "1.2.0"
   s.summary      = "Facilitates registering NFC Interactions with the Blue Bite API."
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
I havent been able to truly test this yet because I haven't been able to get my hands on a ns05 tag that actually exists on the production dashboard, but the request looks accurate as far as what nikita told me to submit.