### PR TITLE
DEC-131: Parse tampered flag from V2 interaction response

### DIFF
--- a/mTag-SDK.podspec
+++ b/mTag-SDK.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "mTag-SDK"
-  s.version      = "1.2.0"
+  s.version      = "1.2.1"
   s.summary      = "Facilitates registering NFC Interactions with the Blue Bite API."
 
   # This description is used to generate tags and improve search results.

--- a/mTag-SDK.podspec
+++ b/mTag-SDK.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "mTag-SDK"
-  s.version      = "1.1.0"
+  s.version      = "1.1.1"
   s.summary      = "Facilitates registering NFC Interactions with the Blue Bite API."
 
   # This description is used to generate tags and improve search results.

--- a/mTag-SDK/API.swift
+++ b/mTag-SDK/API.swift
@@ -260,6 +260,11 @@ open class API: NSObject {
     let device = jsonAsDict["device"] as? [String: Any] ?? nil
     formattedResponse["deviceCountry"] = device?["country"] as? String ?? nil
 
+    if let tampered = jsonAsDict["tampered"] as? Bool {
+      // true if closed, false if opened, null if registered as tamper but not verified by dashboard
+      formattedResponse["tampered"] = tampered
+    }
+
     // get tagVerified.  Should return as Int but check for String just for robustness
     if let verified = jsonAsDict["tag_verified"] as? Int {
       formattedResponse["tagVerified"] = verified == 1 ? true : false


### PR DESCRIPTION
Bumped version to 1.2.1 will need to tag a release with that as well.

Just added a quick conditional to try and pull the tamper status from the V2 response body.  Expects a boolean value as thats what the smartrac swagger file shows and from what I can tell V2 doesn't change that at all.